### PR TITLE
fix test case wrap_row_5, the last row was ignored

### DIFF
--- a/layout.h
+++ b/layout.h
@@ -930,7 +930,7 @@ void lay_arrange_stacked(
         uint32_t count = 0; // count of fillers
         uint32_t squeezed_count = 0; // count of squeezable elements
         uint32_t total = 0;
-        bool hardbreak = false;
+        uint32_t before_wrap_count = 0; // count of elements before wrap
         // first pass: count items that need to be expanded,
         // and the space that is used
         lay_id child = start_child;
@@ -951,12 +951,13 @@ void lay_arrange_stacked(
                     ++squeezed_count;
                 extend += child_rect[dim] + child_rect[2 + dim] + child_margins[wdim];
             }
+            ++ before_wrap_count;
             // wrap on end of line or manual flag
             if (wrap && (
                     total && ((extend > space) ||
                     (child_flags & LAY_BREAK)))) {
                 end_child = child;
-                hardbreak = (child_flags & LAY_BREAK) == LAY_BREAK;
+                before_wrap_count = 0;
                 // add marker for subsequent queries
                 pchild->flags = child_flags | LAY_BREAK;
                 break;
@@ -979,9 +980,8 @@ void lay_arrange_stacked(
             else if (total > 0) {
                 switch (item_flags & LAY_JUSTIFY) {
                 case LAY_JUSTIFY:
-                    // justify when not wrapping or not in last line,
-                    // or not manually breaking
-                    if (!wrap || ((end_child != LAY_INVALID_ID) && !hardbreak))
+                    // justify when not wrapping or at least one remaining element
+                    if (!wrap || end_child != LAY_INVALID_ID || before_wrap_count > 0)
                         spacer = (float)extra_space / (float)(total - 1);
                     break;
                 case LAY_START:

--- a/test_layout.c
+++ b/test_layout.c
@@ -746,9 +746,7 @@ LTEST_DECLARE(wrap_row_5)
 
     lay_run_context(ctx);
 
-    // TODO note we're adding the -5 here so we ignore the last row, which
-    // seems to be bugged
-    for (int16_t i = 0; i < num_items - 5; ++i) {
+    for (int16_t i = 0; i < num_items; ++i) {
         int16_t x, y;
         x = i % 5;
         y = i / 5;


### PR DESCRIPTION
https://github.com/randrew/layout/blob/b0c02829df41b066c5aaedcb946498209bcb38e5/layout.h#L982-L983
According to the original annotation, the last line does not seem to do justify, my modification destroys this behavior

This change has passed all test cases, and it is not known if it will affect other projects
